### PR TITLE
Bump python versions

### DIFF
--- a/.github/workflows/basic-test.yml
+++ b/.github/workflows/basic-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@master
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install Python requirements
         run: pip install pytest pytest-qt -r requirements.txt

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: 3.6
+        python-version: 3.9
 
     - name: Install Python requirements
       run: pip install pytest pytest-qt coverage -r requirements.txt

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
-        exclude:
-          # There's an issue installing PyQt5 on windows with python3.9...
-          - os: windows-latest
-            python-version: 3.9
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # If there are issues on any specific platform/version combos...
+#        exclude:
+#          - os: windows-latest
+#            python-version: 3.10
     steps:
       - uses: actions/checkout@master
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Download links available here:
 
 The Python package is also available on PyPI: https://pypi.org/project/minegauler/.
 
- 1. Python 3.6+ required
+ 1. Python 3.7+ required
  2. Install with `pip install minegauler`
  3. Run with `python -m minegauler`
 
@@ -40,7 +40,7 @@ See note on system dependencies below, or [get in touch](#Contact) if you have a
 
 ### Clone the repo
 
-You will need Python 3.6+ to run the code (see note below about known system dependencies).
+You will need Python 3.7+ to run the code (see note below about known system dependencies).
 
  1. Clone the repo: `git clone https://github.com/LewisGaul/minegauler`
  2. Consider setting up a [virtual environment](https://docs.python.org/3/tutorial/venv.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36']
+target-version = ['py37']
 exclude = '.*venv.*|bootstrap'
 
 [tool.isort]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,6 @@ click==8.0.1
 colorama==0.4.4
 coverage==5.5
 cryptography==3.4.8
-dataclasses==0.8
 docutils==0.17.1
 Flask==2.0.1
 idna==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ idna==3.2
 #--install-option='--no-deps' --install-option='--only-binary=:all:'
 mysql-connector-python==8.0.26
 protobuf==3.17.3
-PyQt5==5.14.2
+PyQt5==5.14.2; platform_system != 'Windows'
+PyQt5==5.15.6; platform_system == 'Windows'
 PyQt5-sip==12.9.0
 requests==2.26.0
 six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -82,12 +82,12 @@ setuptools.setup(
         "Natural Language :: English",
         "Topic :: Games/Entertainment :: Puzzle Games",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "attrs",
         "mysql-connector-python==8.*",
         "PyQt5",
-        "requests==2.*",
+        "requests",
     ],
     package_data={
         "minegauler": [


### PR DESCRIPTION
Drop support for 3.6 (EOL), add testing for 3.10, use 3.9 by default in GitHub actions testing.